### PR TITLE
Added specific phpunit version to composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "kriswallsmith/buzz": ">=0.6",
         "symfony/options-resolver": ">=2.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.14"
+    },
     "autoload": {
         "psr-0": { "Pin": "src/" }
     }


### PR DESCRIPTION
Just for dev, ensures on correct version of phpunit rather than relying on machine wide installation being correct
