### PR TITLE
Add CAD, HKD, JPY to allowed currencies

### DIFF
--- a/src/Pin/Charge/Create.php
+++ b/src/Pin/Charge/Create.php
@@ -45,7 +45,7 @@ class Create implements RequestInterface
                 'capture'        => 'string'
             ))
             ->setAllowedValues(array(
-                'currency' => array('AUD', 'USD', 'NZD', 'SGD', 'EUR', 'GBP')
+                'currency' => array('AUD', 'USD', 'NZD', 'SGD', 'EUR', 'GBP', 'CAD', 'HKD', 'JPY')
             ));
     }
 

--- a/tests/Pin/Test/Charge/CreateTest.php
+++ b/tests/Pin/Test/Charge/CreateTest.php
@@ -73,7 +73,10 @@ class CreateTest extends \PHPUnit_Framework_TestCase
             array('NZD'),
             array('SGD'),
             array('EUR'),
-            array('GBP')
+            array('GBP'),
+            array('CAD'),
+            array('HKD'),
+            array('JPY')
         );
     }
 


### PR DESCRIPTION
additional currencies are now allowed by Pin Payments (https://pin.net.au/docs/currency-support).  @noetix could you please pull this in if it looks good, as we're using your library for Pin Payments.  Thanks!